### PR TITLE
Fix Ruby 2.6.0 dynamic constant assignment on Δ

### DIFF
--- a/lib/australia/postcode.rb
+++ b/lib/australia/postcode.rb
@@ -33,11 +33,11 @@ module Australia
     # @return [Float]
     def distance(other)
       earth_radius = 6371
-      Δlat = radians(other.latitude - latitude)
-      Δlong = radians(other.longitude - longitude)
-      a = sin(Δlat / 2) * sin(Δlat / 2) +
+      lat = radians(other.latitude - latitude)
+      long = radians(other.longitude - longitude)
+      a = sin(lat / 2) * sin(lat / 2) +
           cos(radians(latitude)) * cos(radians(other.latitude)) *
-          sin(Δlong / 2) * sin(Δlong / 2)
+          sin(long / 2) * sin(long / 2)
       c = 2 * atan2(√(a), √(1 - a))
       earth_radius * c
     end


### PR DESCRIPTION
Ruby 2.6.0 did not like this.

```

/var/lib/buildkite-agent/builds/ci-maroon-0/fivegoodfriends/postcoder/vendor/bundle/ruby/2.6.0/bundler/gems/australia_postcode-2adfb919931c/lib/australia/postcode.rb:36: dynamic constant assignment
--
  | Δlat = radians(other.latitude - l...
  | ^~~~~

```